### PR TITLE
[#3] 광고 관리 페이지 UI 구현

### DIFF
--- a/src/components/feature/Card/index.tsx
+++ b/src/components/feature/Card/index.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import Button from '@src/components/shared/Button';
+import CardInfo from '@src/components/feature/CardInfo';
+import InfoTitle from '@src/components/feature/CardTitle';
+import * as S from './styled';
+
+const Card = () => {
+	const [editMode, setEditMode] = useState<boolean>(false);
+
+	const onEditMode = (e: React.MouseEvent<HTMLButtonElement>) => {
+		e.preventDefault();
+		setEditMode((editMode) => !editMode);
+	};
+
+	const onSubmit = (e: React.SyntheticEvent) => {
+		e.preventDefault();
+	};
+
+	return (
+		<S.Wrapper onSubmit={onSubmit}>
+			<S.Space height={40} />
+			<InfoTitle editMode={editMode} value={'웹광고_20210603123030'} />
+
+			<S.Space height={40} />
+			<S.Divider />
+			<CardInfo infoName={'상태'} info={'진행 중'} name={'status'} editMode={editMode} />
+			<S.Divider />
+			<CardInfo infoName={'광고 생성일'} info={'2021-06-04'} name={'startDate'} editMode={editMode} />
+			<S.Divider />
+			<CardInfo infoName={'일 희망 예산'} info={'40만원'} name={'budget'} editMode={editMode} />
+			<S.Divider />
+			<CardInfo infoName={'광고 수익률'} info={'694%'} name={'roas'} editMode={editMode} />
+			<S.Divider />
+			<CardInfo infoName={'매출'} info={'26,071만원'} name={'convValue'} editMode={editMode} />
+			<S.Divider />
+			<CardInfo infoName={'광고 비용'} info={'3,759만원'} name={'cost'} editMode={editMode} />
+			<S.Divider />
+			<S.Action>
+				<S.Space height={20} />
+				<Button type={'button'} theme={'basic'} onClick={onEditMode}>
+					<S.Font>수정하기</S.Font>
+				</Button>
+				<S.Space height={21} />
+			</S.Action>
+		</S.Wrapper>
+	);
+};
+
+export default Card;

--- a/src/components/feature/Card/styled.ts
+++ b/src/components/feature/Card/styled.ts
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.form`
+	border: 1px solid ${({ theme }) => theme.colors.gray[300]};
+	border-radius: 10px;
+	width: 305px;
+	padding: 0 20px;
+`;
+
+export const Font = styled.span`
+	font-weight: 700;
+	font-size: 16px;
+	line-height: 19px;
+	color: ${({ theme }) => theme.colors.black};
+`;
+
+export const NameFont = styled.label`
+	font-weight: 500;
+	font-size: 12px;
+	line-height: 14px;
+	color: ${({ theme }) => theme.colors.gray[400]};
+	width: 100px;
+`;
+
+export const InfoFont = styled.div`
+	font-weight: 700;
+	font-size: 12px;
+	line-height: 14px;
+	color: ${({ theme }) => theme.colors.black};
+`;
+
+type Prop = {
+	height: number;
+};
+
+export const Space = styled.div<Prop>`
+	width: 100%;
+	height: ${({ height }) => `${height}px`};
+`;
+
+export const Divider = styled.div`
+	width: 100%;
+	border: 1px solid ${({ theme }) => theme.colors.gray[200]};
+	background-color: ${({ theme }) => theme.colors.gray[200]};
+`;
+
+export const Action = styled.section``;

--- a/src/components/feature/CardInfo/index.tsx
+++ b/src/components/feature/CardInfo/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import * as S from './styled';
+
+type Props = {
+	infoName: string;
+	info: string;
+	name?: string;
+	editMode: boolean;
+};
+
+const CardInfo = ({ infoName, info, name, editMode }: Props) => {
+	return (
+		<S.BlockWrapper editMode={editMode}>
+			<S.NameFont htmlFor={name}>{infoName}</S.NameFont>
+			{editMode ? <input name={name} defaultValue={info}></input> : <S.InfoFont>{info}</S.InfoFont>}
+		</S.BlockWrapper>
+	);
+};
+
+export default CardInfo;

--- a/src/components/feature/CardInfo/styled.ts
+++ b/src/components/feature/CardInfo/styled.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+type Props = {
+	editMode: boolean;
+};
+
+export const BlockWrapper = styled.div<Props>`
+	display: flex;
+	align-items: center;
+	height: 40px;
+`;
+
+export const NameFont = styled.label`
+	font-weight: 500;
+	font-size: 12px;
+	line-height: 14px;
+	color: ${({ theme }) => theme.colors.gray[400]};
+	width: 100px;
+`;
+
+export const InfoFont = styled.div`
+	font-weight: 700;
+	font-size: 12px;
+	line-height: 14px;
+	color: ${({ theme }) => theme.colors.black};
+`;

--- a/src/components/feature/CardList/index.tsx
+++ b/src/components/feature/CardList/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Card from '../Card';
+import * as S from './styled';
+
+const CardList = () => {
+	return (
+		<S.Wrapper>
+			<Card />
+		</S.Wrapper>
+	);
+};
+export default CardList;

--- a/src/components/feature/CardList/styled.ts
+++ b/src/components/feature/CardList/styled.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.section`
+	display: flex;
+	flex-wrap: wrap;
+	gap: 20px;
+`;

--- a/src/components/feature/CardTitle/index.tsx
+++ b/src/components/feature/CardTitle/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import * as S from './styled';
+
+type Props = {
+	value?: string;
+	editMode: boolean;
+};
+
+const CardTitle = ({ value, editMode }: Props) => {
+	return <S.Title>{editMode ? <input name="title" defaultValue={value}></input> : <S.Font>{value}</S.Font>}</S.Title>;
+};
+
+export default CardTitle;

--- a/src/components/feature/CardTitle/styled.ts
+++ b/src/components/feature/CardTitle/styled.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const Title = styled.div`
+	height: 19px;
+`;
+
+export const Font = styled.span`
+	font-weight: 700;
+	font-size: 16px;
+	line-height: 19px;
+	color: ${({ theme }) => theme.colors.black};
+`;

--- a/src/components/shared/Button/index.tsx
+++ b/src/components/shared/Button/index.tsx
@@ -1,0 +1,42 @@
+/* eslint no-unused-vars: 0 */
+
+import { theme } from '@src/styles';
+import React, { PropsWithChildren } from 'react';
+import * as S from './styled';
+
+const themeTable = {
+	main: {
+		backgroundColor: theme.colors.primary,
+		color: theme.colors.white,
+		border: 'none',
+	},
+	basic: {
+		backgroundColor: theme.colors.white,
+		color: theme.colors.black,
+		border: `1px solid ${theme.colors.gray[300]}`,
+	},
+};
+
+type Props = {
+	theme: 'main' | 'basic';
+	type: 'submit' | 'button' | 'reset';
+	disabled?: boolean;
+	onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+} & PropsWithChildren;
+
+const Button = ({ children, theme, type, disabled, onClick }: Props) => {
+	return (
+		<S.Button
+			type={type}
+			disabled={disabled}
+			bgr={themeTable[theme].backgroundColor}
+			color={themeTable[theme].color}
+			border={themeTable[theme].border}
+			onClick={onClick}
+		>
+			{children}
+		</S.Button>
+	);
+};
+
+export default Button;

--- a/src/components/shared/Button/styled.ts
+++ b/src/components/shared/Button/styled.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+type Props = {
+	bgr: string;
+	color: string;
+	border: string;
+};
+export const Button = styled.button<Props>`
+	background-color: ${({ bgr }) => bgr};
+	color: ${({ color }) => color};
+	padding: 12px 20px;
+	border: ${({ border }) => border};
+	border-radius: 10px;
+`;

--- a/src/pages/ADManagement/index.tsx
+++ b/src/pages/ADManagement/index.tsx
@@ -1,5 +1,24 @@
+import CardList from '@src/components/feature/CardList';
+import Button from '@src/components/shared/Button';
+import * as S from './styled';
+
 const ADManagement = () => {
-	return <div>ADManagement Page</div>;
+	return (
+		<S.Wrapper>
+			<S.Header>
+				<Button type={'button'} theme={'basic'}>
+					<S.Font>전체 광고</S.Font>
+				</Button>
+				<Button type={'button'} theme={'main'}>
+					<S.Font>광고 만들기</S.Font>
+				</Button>
+			</S.Header>
+			<S.Space height={40} />
+			<S.Content>
+				<CardList />
+			</S.Content>
+		</S.Wrapper>
+	);
 };
 
 export default ADManagement;

--- a/src/pages/ADManagement/styled.ts
+++ b/src/pages/ADManagement/styled.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.article`
+	padding: 40px;
+`;
+
+export const Header = styled.header`
+	display: flex;
+	justify-content: space-between;
+`;
+
+type Prop = {
+	height: number;
+};
+
+export const Space = styled.div<Prop>`
+	width: 100%;
+	height: ${({ height }) => `${height}px`};
+`;
+
+export const Content = styled.section``;
+
+export const Font = styled.span`
+	font-style: normal;
+	font-weight: 700;
+	font-size: 14px;
+	line-height: 16px;
+`;


### PR DESCRIPTION
## 해결한 이슈

- #3 

<br />

## 해결 방법

`광고 관리 페이지 UI 구현`

- 더미 데이터로 구현 완료했으며, 기능 작업 전입니다.

`버튼 컴포넌트 구현`
 
- 공통적으로 사용가능한 버튼 컴포넌트를 구현했습니다.

`main theme button `

```
<Button type={'button'} theme={'main'} >
	<S.Font>광고 만들기</S.Font>
</Button>
```

![image](https://user-images.githubusercontent.com/40523487/200137030-e57fb22e-97db-41db-87a2-c20cf9e0cb7f.png)  

`basic theme button `

![image](https://user-images.githubusercontent.com/40523487/200137049-403290f3-7ca8-4320-9a7a-98d057f0267a.png)

```
<Button type={'button'} theme={'basic'} onClick={onEditMode}>
	<S.Font>수정하기</S.Font>
</Button>
```
<br />

## 캡처 첨부
`광고 관리 페이지 UI`
![image](https://user-images.githubusercontent.com/40523487/200136911-de17ceeb-f22a-4136-bb9a-78d7e0d013c8.png)


관련 이슈 제목 1

- 내용을 입력해주세요.

<br />

## 추가적인 태스크

- [추가 수정 예정] DropDown 컴포넌트 / Typography 컴포넌트 개발 완료되면 적용할 예정입니다.

- #4 

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
