### PR TITLE
[#4] Typography 공통 컴포넌트 UI 구현

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
-export {};
+// shared components
+export { default as Typography } from '@src/components/shared/Typography';

--- a/src/components/shared/Typography/index.tsx
+++ b/src/components/shared/Typography/index.tsx
@@ -1,0 +1,24 @@
+import { PropsWithChildren } from 'react';
+import * as S from './styled';
+
+type Props = {
+	variant: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'caption' | 'span' | 'div';
+	margin?: string;
+	padding?: string;
+	fontSize?: string;
+	fontWeight?: number;
+	lineHeight?: string;
+	color?: string;
+	align?: 'center' | 'inherit' | 'justify' | 'left' | 'right';
+	whiteSpace?: 'normal' | 'nowrap' | 'pre' | 'pre-wrap';
+} & PropsWithChildren;
+
+const Typography = ({ children, variant, ...props }: Props) => {
+	return (
+		<S.Component as={variant} {...props}>
+			{children}
+		</S.Component>
+	);
+};
+
+export default Typography;

--- a/src/components/shared/Typography/styled.ts
+++ b/src/components/shared/Typography/styled.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+type ComponentProps = {
+	margin?: string;
+	padding?: string;
+	fontSize?: string;
+	fontWeight?: number;
+	lineHeight?: string;
+	color?: string;
+	align?: 'center' | 'inherit' | 'justify' | 'left' | 'right';
+	whiteSpace?: 'normal' | 'nowrap' | 'pre' | 'pre-wrap';
+};
+
+export const Component = styled.div<ComponentProps>`
+	margin: ${({ margin }) => margin && margin};
+	padding: ${({ padding }) => padding && padding};
+	font-size: ${({ fontSize }) => fontSize && fontSize};
+	font-weight: ${({ fontWeight }) => fontWeight && fontWeight};
+	line-height: ${({ lineHeight }) => lineHeight && lineHeight};
+	color: ${({ color, theme }) => (color ? color : theme.colors.black)};
+	text-align: ${({ align }) => align && align};
+	white-space: ${({ whiteSpace }) => whiteSpace && whiteSpace};
+`;


### PR DESCRIPTION
## 해결한 이슈

- #4 

<br />

## 해결 방법

`동적으로 HTML tag 를 설정해서 스타일 컴포넌트를 만드는 법`

- (styled-components 기준) [as 프로퍼티](https://styled-components.com/docs/api#as-polymorphic-prop)를 사용했습니다.
- 정의한 Typograhpy 컴포넌트에 내려줄 props 중 `varient` prop 를 `as` 프로퍼티에 할당해주면 `런타임(runtime)` 에 동적으로 할당해준 태그 이름의 요소로 렌더링 합니다. ( `varient` 라는 이름은 UI 라이브러리 중 [Material UI - Typography API](https://mui.com/material-ui/api/typography/)를 참고 했습니다.
- 나머지 스타일 props 들을 디스트럭처링을 통해 넘겨주어 넘겨준 스타일링 prop 이 적용되도록 구현했습니다.

<br />


## 추가적인 태스크

- [x] 현재 열어둔 props 외의 적용해야할 css 속성이 있을 경우에 추가적인 props 확장이 필요할 수 있으며, 현재 열어둔 props 에 대해서도 해당 속성값이 props 로 내려왔을때만 적용하도록 하였는데, theme 에 있는 값으로 Default 값을 설정해되 좋을 것 같습니다.

<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
