### PR TITLE
[#15] 드롭박스 UI 구현 및 코드 구조 개선

### DIFF
--- a/src/assets/images/UpArrow.svg
+++ b/src/assets/images/UpArrow.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.41 0.589966L6 5.16997L10.59 0.589966L12 1.99997L6 7.99997L0 1.99997L1.41 0.589966Z" fill="#3A474E"/>
+</svg>

--- a/src/assets/images/bluecircle.svg
+++ b/src/assets/images/bluecircle.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="5" cy="5" r="5" fill="#4FADF7"/>
+</svg>

--- a/src/assets/images/greencircle.svg
+++ b/src/assets/images/greencircle.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="5" cy="5" r="5" fill="#85DA47"/>
+</svg>

--- a/src/components/shared/DropDown/index.tsx
+++ b/src/components/shared/DropDown/index.tsx
@@ -1,48 +1,61 @@
 import React, { useState, useRef, PropsWithChildren } from 'react';
 
+import UpArrow from '@src/assets/images/UpArrow.svg';
+import bluecircle from '@src/assets/images/bluecircle.svg';
+import greencircle from '@src/assets/images/greencircle.svg';
 import { ListType } from '../../../constants/dropDownDataList';
 import { useOutsideClick } from '@src/hooks/useOutsideClick';
 import * as S from './styled';
 
 type Props = {
+	isAd?: boolean;
+	adColor?: string;
+	isBig?: boolean;
 	list: ListType[];
 } & PropsWithChildren;
 
-const DropDown = (props: Props) => {
+const DropDown = ({ ...props }: Props) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [clickedData, setClickedData] = useState(props.list[0].value);
 	const clickRef = useRef() as React.MutableRefObject<HTMLDivElement>;
 
 	useOutsideClick(clickRef, setIsOpen);
 
+	const handleClick = (value: string): React.MouseEventHandler<HTMLLIElement> | undefined | void => {
+		setIsOpen(!isOpen);
+		setClickedData(value);
+	};
+
 	return (
-		<S.Container ref={clickRef}>
-			<div>
-				<button
-					onClick={() => {
-						setIsOpen(!isOpen);
-					}}
-				>
-					{clickedData}
-				</button>
-			</div>
+		<S.Container isBig={props.isBig} ref={clickRef}>
+			<S.SeletedData
+				isBig={props.isBig}
+				onClick={() => {
+					setIsOpen(!isOpen);
+				}}
+			>
+				{props.isAd && (props.adColor === 'blue' ? <img src={bluecircle} /> : <img src={greencircle} />)}
+				<p>{clickedData}</p>
+				<img className="arrow" src={UpArrow} />
+			</S.SeletedData>
+
 			{isOpen && (
-				<ul>
+				<S.DropData isBig={props.isBig}>
 					{props.list.map((el) => (
-						<li
-							key={el.id}
-							onClick={() => {
-								setIsOpen(!isOpen);
-								setClickedData(() => el.value);
-							}}
-						>
+						<li className="data-list" key={el.id} onClick={() => handleClick(el.value)}>
 							{el.value}
 						</li>
 					))}
-				</ul>
+				</S.DropData>
 			)}
 		</S.Container>
 	);
 };
 
 export default DropDown;
+
+DropDown.defaultProps = {
+	isAd: false,
+	adColor: 'blue',
+	isBig: false,
+};

--- a/src/components/shared/DropDown/styled.ts
+++ b/src/components/shared/DropDown/styled.ts
@@ -1,21 +1,55 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
-	width: 500px;
+export const Container = styled.div<{ isBig?: boolean }>`
+	width: ${(props) => (props.isBig ? '240px' : '123px')};
+	height: ${(props) => (props.isBig ? '60px' : '40px')};
 	display: flex;
 	flex-direction: column;
 	position: relative;
-	> div {
-		width: 100%;
-		> button {
-			width: 150px;
+	margin: 100px;
+`;
+
+export const SeletedData = styled.button<{ isBig?: boolean }>`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	height: 100%;
+	border: 1px solid ${({ theme }) => theme.colors.gray[300]};
+	background-color: ${({ theme }) => theme.colors.white};
+	border-radius: 10px;
+	padding: ${(props) => (props.isBig ? '0 26px 0 20px' : '0 16px 0 20px')};
+	font-size: ${(props) => (props.isBig ? '16px' : '14px')};
+	font-weight: ${(props) => (props.isBig ? '700' : '500')};
+	color: ${({ theme }) => theme.colors.black};
+	cursor: pointer;
+	.circle {
+		width: 10px;
+		background-color: #4fadf7;
+	}
+`;
+
+export const DropData = styled.ul<{ isBig?: boolean }>`
+	display: flex;
+	flex-direction: column;
+	position: absolute;
+	top: ${(props) => (props.isBig ? '60px' : '40px')};
+	width: 100%;
+	border: 1px solid ${({ theme }) => theme.colors.gray[300]};
+	font-weight: ${(props) => (props.isBig ? '700' : '500')};
+	border-radius: 10px;
+	cursor: pointer;
+	.data-list {
+		display: flex;
+		align-items: center;
+		padding: ${(props) => (props.isBig ? '0 26px 0 20px' : '0 16px 0 20px')};
+		height: 40px;
+		color: ${({ theme }) => theme.colors.black};
+		border-bottom: 1px solid ${({ theme }) => theme.colors.gray[300]};
+		height: ${(props) => (props.isBig ? '60px' : '40px')};
+		font-size: ${(props) => (props.isBig ? '16px' : '14px')};
+		&:hover {
+			font-size: ${(props) => (props.isBig ? '18px' : '16px')};
 		}
 	}
-	> ul {
-		width: 100%;
-		> li {
-			width: 100%;
-		}
-	}
-	margin-bottom: 100px;
 `;


### PR DESCRIPTION
## 해결한 이슈

- #15 

<br />

## 해결 방법

1. props를 이용한 재사용이 가능한 드롭박스 UI 구현
2. onClick 관리하는 handler 함수 추가
3. html 태그를 활용한 style 변경 했던 것 삭제

<br />

## 캡처 첨부

<img width="294" alt="image" src="https://user-images.githubusercontent.com/97100045/200174856-ec3fe10b-1562-4b87-913a-cec6037a705f.png">

큰 드롭박스를 쓸 경우 `isBig={true}` 입력


<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
