### PR TITLE
[#21] 숫자 금액 데이터 XXX원 단위 데이터로 변경하는 유틸 함수 구현

### DIFF
--- a/src/components/feature/Card/index.tsx
+++ b/src/components/feature/Card/index.tsx
@@ -3,6 +3,7 @@ import Button from '@src/components/shared/Button';
 import * as S from './styled';
 import { AdProgress } from '@src/types/advertise';
 import { dateToString } from '@src/utils/DateUtils';
+import { moneyExpressionConverter } from '@src/utils/NumberUtils';
 
 type Props = {
 	item: AdProgress;
@@ -92,7 +93,7 @@ const Card = ({ item, data, setData }: Props) => {
 					{editMode ? (
 						<input type="number" ref={budgetRef} defaultValue={item.budget}></input>
 					) : (
-						<S.InfoFont>{item.budget}원</S.InfoFont>
+						<S.InfoFont>{moneyExpressionConverter(item.budget)}</S.InfoFont>
 					)}
 				</S.BlockWrapper>
 				<S.Divider />
@@ -110,7 +111,7 @@ const Card = ({ item, data, setData }: Props) => {
 					{editMode ? (
 						<input type="number" name={'convValue'} ref={convValueRef} defaultValue={item.report.convValue}></input>
 					) : (
-						<S.InfoFont>{item.report.convValue}원</S.InfoFont>
+						<S.InfoFont>{moneyExpressionConverter(item.report.convValue)}</S.InfoFont>
 					)}
 				</S.BlockWrapper>
 				<S.Divider />
@@ -119,7 +120,7 @@ const Card = ({ item, data, setData }: Props) => {
 					{editMode ? (
 						<input type="number" name={'cost'} ref={costRef} defaultValue={item.report.cost}></input>
 					) : (
-						<S.InfoFont>{item.report.cost}원</S.InfoFont>
+						<S.InfoFont>{moneyExpressionConverter(item.report.cost)}</S.InfoFont>
 					)}
 				</S.BlockWrapper>
 				<S.Divider />

--- a/src/utils/NumberUtils.ts
+++ b/src/utils/NumberUtils.ts
@@ -1,0 +1,9 @@
+const MAN_WON = 10000;
+
+export const numberWithCommasConverter = (n: number) => n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+export const moneyExpressionConverter = (money: number) => {
+	return money / MAN_WON < 1
+		? `${numberWithCommasConverter(money)}원`
+		: `${numberWithCommasConverter(Math.floor(money / MAN_WON))}만원`;
+};

--- a/src/utils/NumberUtils.ts
+++ b/src/utils/NumberUtils.ts
@@ -1,9 +1,16 @@
-const MAN_WON = 10000;
+const TEN = 10;
+const ONE_THOUSAND = 1_000;
+const TEN_THOUSAND = 10_000;
+const ONE_HUNDRED_THOUSAND = 100_000;
 
 export const numberWithCommasConverter = (n: number) => n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
 export const moneyExpressionConverter = (money: number) => {
-	return money / MAN_WON < 1
-		? `${numberWithCommasConverter(money)}원`
-		: `${numberWithCommasConverter(Math.floor(money / MAN_WON))}만원`;
+	if (money / TEN_THOUSAND < 1) return `${numberWithCommasConverter(money)}원`;
+	if (money % TEN_THOUSAND === 0) return `${numberWithCommasConverter(Math.floor(money / TEN_THOUSAND))}만원`;
+	if (money < ONE_HUNDRED_THOUSAND) return `${Math.floor(money / ONE_THOUSAND)}천원`;
+
+	return Math.floor((money / ONE_THOUSAND) % TEN) > 0
+		? `${Math.floor(money / TEN_THOUSAND)}만 ${Math.floor(money / ONE_THOUSAND) % TEN}천원`
+		: `${Math.floor(money / TEN_THOUSAND)}만원`;
 };


### PR DESCRIPTION
## 해결한 이슈

- #21 

<br />

## 해결 방법

`XXX,XXX만원`, `XXX원` 구분해서 렌더링

+ `수정 모드` 일때는 기존 숫자형 데이터 형태로 표현됨 (Only. View 모드 일때만)

+ 숫자형 데이터 N 에 대해 `1만원(10,000)` 보다 작은 금액이면 `XXX원`, 크다면 `(N / 10000)만원` 형태로 반환하도록 구현.

```ts
const TEN = 10;
const ONE_THOUSAND = 1_000;
const TEN_THOUSAND = 10_000;
const ONE_HUNDRED_THOUSAND = 100_000;

export const numberWithCommasConverter = (n: number) => n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');

export const moneyExpressionConverter = (money: number) => {
	if (money / TEN_THOUSAND < 1) return `${numberWithCommasConverter(money)}원`;  // 10_000원 미만
	if (money % TEN_THOUSAND === 0) return `${numberWithCommasConverter(Math.floor(money / TEN_THOUSAND))}만원`;  // 10_000원 이상, 10_000원 단위로 떨어지는 경우
	if (money < ONE_HUNDRED_THOUSAND) return `${Math.floor(money / ONE_THOUSAND)}천원`; //  10_000원 이상, 100_000원 미만, 10_000원 단위로 떨어지지 않는 경우
        
        // 그 외
	return Math.floor((money / ONE_THOUSAND) % TEN) > 0
		? `${Math.floor(money / TEN_THOUSAND)}만 ${Math.floor(money / ONE_THOUSAND) % TEN}천원`
		: `${Math.floor(money / TEN_THOUSAND)}만원`;
};
```

<br />

## 캡처 첨부

`광고 관리 - 금액 수정`

![ad_edit_money](https://user-images.githubusercontent.com/50790145/200191731-4ffda247-7dc2-4cb9-a755-9ce3fc7cb5f0.gif)

<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
